### PR TITLE
:alembic: Model redesign to single-branch, use Dice, Mish/Swish and PuP

### DIFF
--- a/s2s2net/model.py
+++ b/s2s2net/model.py
@@ -72,6 +72,7 @@ class S2S2Net(pl.LightningModule):
             drop_rate=0.0,
             attn_drop_rate=0.0,
             drop_path_rate=0.1,
+            act_cfg=dict(type="Swish"),
         )
 
         ## Middle Module (Decoder). SegFormer's All-MLP Head config from
@@ -82,8 +83,10 @@ class S2S2Net(pl.LightningModule):
             channels=256,
             dropout_ratio=0.1,
             num_classes=16,  # output sixteen channels
-            # norm_cfg=dict(type="SyncBN", requires_grad=True), # for multi-GPU
+            # norm_cfg=dict(type="SyncBN", requires_grad=True),  # for multi-GPU
             align_corners=False,
+            act_cfg=dict(type="Swish"),
+            loss_decode=[],
         )
 
         ## Upsampling layers (Output). 1st one to get back original image size
@@ -140,9 +143,10 @@ class S2S2Net(pl.LightningModule):
         segmmask_conv_output_0: torch.Tensor = self.segmmask_post_upsample_conv_layer_0(
             segmmask_up_output_0
         )
-        # print("segmmask_conv_output_0.shape:", segmmask_conv_output_0.shape)  # (8, 8, 512, 512)
+        segmmask_activation_output_0: torch.Tensor = F.mish(segmmask_conv_output_0)
+        # print("segmmask_activation_output_0.shape:", segmmask_activation_output_0.shape)  # (8, 8, 512, 512)
         segmmask_up_output_1: torch.Tensor = self.segmmask_upsample_1(
-            segmmask_conv_output_0
+            segmmask_activation_output_0
         )
         segmmask_conv_output_1: torch.Tensor = self.segmmask_post_upsample_conv_layer_1(
             segmmask_up_output_1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,9 +42,8 @@ def test_s2s2net():
 
     # Inference/Prediction
     predictions: list = trainer.predict(model=model, dataloaders=dataloader)
-    segmmask, superres = predictions[0]
+    segmmask = predictions[0]
     assert segmmask.shape == (1, 1, 2560, 2560)
-    assert superres.shape == (1, 4, 2560, 2560)
 
     # Test/Evaluation
     scores: list[dict] = trainer.test(model=model, dataloaders=dataloader)


### PR DESCRIPTION
Re-architecting S2S2Net to be simpler (single-branch instead of dual-branch) and peform better (using a nicer loss model). Recommendations from @Ziwei-0129.

TODO:
- [x] Change from using dual-branch (in 979358749bdbca1587322ff4cd14504e882aa3b3) to single-branch (bf4f34efc46c9a01b4d9e79ea7571a1ec6abf15f)
  - Mainly because the dual-branch didn't really help for our task as it needed too much tweaking/hyperparameter tuning
  - Really, a single-branch network that's well designed can do the segmentation+super-resolution task equally well
- [x] Swap out Focal Loss for a BinaryCrossEntropyLoss+DiceLoss (from https://smp.readthedocs.io/en/v0.2.1/losses.html#diceloss), also using soft labels of 0.1 (28892798b3ad315e7ee1a6d77897cc3910f328f9)
- [x] Add Mish activation function to the upsampling head, change Segformer activation to Swish (f5da3c7a931432fe535de14a1837de80b0d5974f)
- [x] Change from x4x5 head to progressive upsampling head x2x2x2x2.5 (50dcc4a2a3870237854d8f9c25b953e1fb1170a4)

References:
- https://medium.com/ai-salon/understanding-dice-loss-for-crisp-boundary-detection-bb30c2e5f62b
- Deng, R., Shen, C., Liu, S., Wang, H., & Liu, X. (2018). Learning to predict crisp boundaries (arXiv:1807.10097). arXiv. https://doi.org/10.48550/arXiv.1807.10097
- Ma, J., Chen, J., Ng, M., Huang, R., Li, Y., Li, C., Yang, X., & Martel, A. L. (2021). Loss odyssey in medical image segmentation. Medical Image Analysis, 71, 102035. https://doi.org/10.1016/j.media.2021.102035
- Müller, R., Kornblith, S., & Hinton, G. (2020). When Does Label Smoothing Help? (arXiv:1906.02629). arXiv. https://doi.org/10.48550/arXiv.1906.02629